### PR TITLE
封面页的若干修正

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -5,7 +5,7 @@
 \graphicspath{{figures/}}
 
 \title{中国科学技术大学\\本硕博毕业论文模板示例文档}
-\secrettext{绝密\quad 小于等于20年}
+\secrettext{机密\quad 小于等于20年}   % 内部|秘密|机密，若为空值，则论文不保密
 \author{赵钱孙}
 \depart{一二三系}
 \major{XXXX专业}
@@ -14,7 +14,7 @@
 \submitdate{二〇九九年十三月}
 
 \entitle{USTC Thesis Template for Bachelor, Master and Doctor\\User's Guide(Beta)}
-\ensecrettext{绝密\quad 小于等于20年}
+\ensecrettext{Confidential\quad Less than or equal to 20 years}  % Internal|Secret|Confidential
 \enauthor{Qiansun Zhao}
 \enmajor{Whatever}
 \enadvisor{Prof. Xueshen Qian\\ & Prof. Zhengdao Li}

--- a/main.tex
+++ b/main.tex
@@ -5,7 +5,7 @@
 \graphicspath{{figures/}}
 
 \title{中国科学技术大学\\本硕博毕业论文模板示例文档}
-\secrettext{机密\quad 小于等于20年}   % 内部|秘密|机密，若为空值，则论文不保密
+%\secrettext{机密\quad 小于等于20年}   % 内部|秘密|机密，若为空值，则论文不保密
 \author{赵钱孙}
 \depart{一二三系}
 \major{XXXX专业}
@@ -14,7 +14,7 @@
 \submitdate{二〇九九年十三月}
 
 \entitle{USTC Thesis Template for Bachelor, Master and Doctor\\User's Guide(Beta)}
-\ensecrettext{Confidential\quad Less than or equal to 20 years}  % Internal|Secret|Confidential
+%\ensecrettext{Confidential\quad Less than or equal to 20 years}  % Internal|Secret|Confidential
 \enauthor{Qiansun Zhao}
 \enmajor{Whatever}
 \enadvisor{Prof. Xueshen Qian\\ & Prof. Zhengdao Li}

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -181,7 +181,7 @@
         left=3.2cm, right=3.2cm,
         includehead,
         headheight=0cm, headsep=1.2cm,
-        footskip=3.0cm %, showframe=true
+        footskip=3.0cm
     }
     \thispagestyle{ustc@titlepage}
     \pdfbookmark[-1]{\ustc@title}{title}
@@ -222,7 +222,7 @@
         left=3.2cm, right=3.2cm,
         includehead,
         headheight=0cm, headsep=1cm,
-        footskip=3.0cm %, showframe=true
+        footskip=3.0cm
     }
     \thispagestyle{ustc@entitlepage}
     \begin{center}

--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -174,10 +174,7 @@
 \fi
 
 % 中文封面
-\newcommand{\ps@ustc@titlepage}{
-\renewcommand{\@oddhead}{\hfill {\zihao{4}\ustc@secrettext}}
-\renewcommand{\@evenhead}\@oddhead}
-
+\newpagestyle{ustc@titlepage}{\sethead{}{}{\fangsong \zihao{4}\ustc@secrettext}}
 \newcommand\make@cntitle{
     \newgeometry{
         top=4cm, bottom=3.8cm,
@@ -218,10 +215,7 @@
 }
 
 % 英文封面
-\newcommand{\ps@ustc@entitlepage}{
-\renewcommand{\@oddhead}{\hfill {\zihao{4}\ustc@ensecrettext}}
-\renewcommand{\@evenhead}\@oddhead}
-
+\newpagestyle{ustc@entitlepage}{\sethead{}{}{\zihao{4}\ustc@ensecrettext}}
 \newcommand\make@entitle{
     \newgeometry{
         top=4cm, bottom=3.8cm,


### PR DESCRIPTION
1. 密级的可选值为“内部”、“秘密”、“机密”；对应的英文尚不确定，暂时用“Internal”、“Secret”和“Confidential”；
2. 中英文封面的页面用`titleps`包提供的命令进行设置；
3. 中文密级的字体要求是**仿宋**