### PR TITLE
ABSTRACT用arial大写

### DIFF
--- a/ustcthesis.cls
+++ b/ustcthesis.cls
@@ -77,7 +77,11 @@
         { \fontsize{#1}{1.2 \dimexpr#1} }
     \linespread{1}\selectfont\relax}
 \newenvironment{cnabstract}{\chapter{摘\quad 要}}{}
-\newenvironment{enabstract}{\chapter{Abstract}}{}
+\newenvironment{enabstract}{
+    \ctexset {
+        chapter/format += \sffamily\bfseries\setfontsize{16bp}
+    }
+    \chapter{ABSTRACT}}{}
 \newcommand\keywords[1]{\vspace{3.5ex}\noindent{\textbf{关键词：} #1}}
 \newcommand\enkeywords[1]{\vspace{3.5ex}\noindent{\textbf{Key Words：} #1}}
 \ustc@define@term{title}


### PR DESCRIPTION
我把英文abstract改成arial大写，但是有问题：
1. 页眉上的章节标题也变成大写了；我下一步打算用titleps去改掉。
2. 中、英文摘要的后一页留有页眉。 空白页显示页码是latex的book的默认设置，我需要征求一下意见。
另外《规范》里说“自中文摘要起双面印刷”，那么英文abstract要不要从右边开起？